### PR TITLE
Special Session Week

### DIFF
--- a/mission/src/components/ItemList/Item.vue
+++ b/mission/src/components/ItemList/Item.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="has-text-left">
-    <img data-test="item-img" :src="item.img" />
+    <img data-test="item-img" :src="img" />
     <div class="has-text-weight-bold">
       <span
-        v-show="item.isDiscount"
-        :class="{ 'has-text-danger': item.isDiscount }"
+        v-show="isDiscount"
+        :class="{ 'has-text-danger': isDiscount }"
         data-test="discount-rate"
       >
         {{ discountRate }}
       </span>
       <span data-test="final-price">{{ finalPrice }}</span>
     </div>
-    <h4 data-test="item-title">{{ item.title }}</h4>
+    <h4 data-test="item-title">{{ title }}</h4>
     <div data-test="item-discription" class="is-size-7">
-      {{ item.discription }}
+      {{ discription }}
     </div>
   </div>
 </template>
@@ -22,20 +22,54 @@
 export default {
   name: 'ItemListItem',
   props: {
-    item: Object,
+    id: {
+      type: Number,
+      default: 1,
+      required: true,
+    },
+    img: {
+      type: String,
+      default: 'https://picsum.photos/200',
+      required: true,
+    },
+    title: {
+      type: String,
+      default: '',
+      required: true,
+    },
+    isDiscount: {
+      type: Boolean,
+      default: false,
+      required: true,
+    },
+    discountRate: {
+      type: Number,
+      default: null,
+      required: true,
+    },
+    originalPrice: {
+      type: Number,
+      default: 0,
+      required: true,
+    },
+    discription: {
+      type: String,
+      default: '',
+      required: true,
+    },
   },
   computed: {
     finalPrice() {
-      const price = this.item.originalPrice;
-      const rate = this.item.discountRate;
-      const discount = this.item.isDiscount;
+      const price = this.originalPrice;
+      const rate = this.discountRate;
+      const discount = this.isDiscount;
       const discountedPrice = price - price * (rate / 100);
       return discount
         ? `${discountedPrice.toLocaleString()}원`
         : `${price.toLocaleString()}원`;
     },
     discountRate() {
-      return `${this.item.discountRate}%`;
+      return `${this.discountRate}%`;
     },
   },
 };

--- a/mission/src/views/ItemList.vue
+++ b/mission/src/views/ItemList.vue
@@ -2,7 +2,13 @@
   <div class="container mb-5 pb-5" data-test="item-list-page">
     <Item
       v-for="item in items"
-      :item="item"
+      :id="item.id"
+      :img="item.img"
+      :title="item.title"
+      :isDiscount="item.isDiscount"
+      :discountRate="item.discountRate"
+      :originalPrice="item.originalPrice"
+      :discription="item.discription"
       :key="item.id"
       class="item mx-3 my-2"
     />

--- a/mission/tests/unit/ItemList/Item.spec.js
+++ b/mission/tests/unit/ItemList/Item.spec.js
@@ -10,15 +10,12 @@ describe('test Item.vue에 props의 선언만 있는 상태에서 값을 렌더�
       }
     });
   })
-  /* 모든 테스트에서 can not read property 'toLocaleString' of undefined */
   it('tests item의 img url data를 렌더링할 element가 존재하는지 여부와 화면상에 보여지는지의 여부', () => {
     expect(wrapper.find('img[data-test="item-img"]').exists()).toBe(true)
     expect(wrapper.find('img[data-test="item-img"]').isVisible()).toBe(true)
   })
   it('tests item의 discount rate data를 렌더링할 element가 존재하는지 여부와 화면상에 보여지는지의 여부', () => {
     expect(wrapper.find('[data-test="discount-rate"]').exists()).toBe(true)
-    /* Conditional rendering 을 다루는법 */
-    // expect(wrapper.find('[data-test="discount-rate"]').isVisible()).toBe(true)
   })
   it('tests item의 final price data를 렌더링할 element가 존재하는지 여부와 화면상에 보여지는지의 여부', () => {
     expect(wrapper.find('[data-test="final-price"]').exists()).toBe(true)
@@ -33,17 +30,7 @@ describe('test Item.vue에 props의 선언만 있는 상태에서 값을 렌더�
     expect(wrapper.find('[data-test="item-discription"]').isVisible()).toBe(true);
 
   })
-  it('item의 img element에 보여질 data가 props 로부터 전달되어 원하는 값이 template에 나타나는지 확인합니다.', async () => {
-    await wrapper.setProps({
-      item: [
-        {
-          img: 'testUrl'
-        }
-      ]
-    })
-    /* undefined.. */
-    // expect(wrapper.find('[data-test="item-img"]').attributes().src).toEqual('testUrl')
-  })
+
 });
 
 describe('Item.vue에 props로 전달한 (test)data를 정의하고 각 항목을 테스트 합니다', () => {
@@ -67,29 +54,8 @@ describe('Item.vue에 props로 전달한 (test)data를 정의하고 각 항목�
     });
   })
 
-  it('컴포넌트에 props가 성공적으로 전달되었는지 확인합니다', () => {
-    expect(wrapper.props()).toEqual({
-      item: [
-        {
-          id: 1,
-          img: 'testUrl',
-          title: 'test Item title',
-          isDiscount: false,
-          discountRate: 0,
-          originalPrice: 200000,
-          discription: 'test discription'
-        }
-      ]
-    })
 
-  });
 
-  it('원가와 할인율을 계산한 computed property인 final price가 잘 렌더링 되는지 확인합니다.', () => {
-    /* can not read property finalPrice of undefined */
-    // expect(wrapper.props().computed.finalPrice.call())
-    /* */
-    // expect(wrapper.get('[data-test="final-price"]').text()).toBe(`${finalPrice.toLocaleString()}원`)
-  })
 });
 
 


### PR DESCRIPTION
# 3주차: 쇼핑몰 상품 목록 페이지 구현하기

## 출제자 의도 되짚어보기

- 재사용성을 위해 구현한 컴포넌트를 가져와 사용하며, 부모-자식 간 컴포넌트끼리 props와 event handling을 이용해 필요한 데이터를 주고 받을 수 있어야 한다.
>> 기능구현에는 문제가 없겠지만, TC 작성시 Props의 Validation을 추가적으로 선언해주지 않는다면 props들이 undefined 되는 에러를 맞닥뜨리게 되는데 이또한 의도하신 부분이 아닌가 생각이 되었습니다.

## 답안 및 해설

- Validation을 고려하지않고 props를 object로 전달해 주었을때 (Parent Component)
<img width="420" alt="Screen Shot 2022-02-01 at 11 58 06 am" src="https://user-images.githubusercontent.com/16056892/151907494-a4ba0b20-7bb5-49ce-a1e2-3a9d5ad691d8.png">
- Props Validation 을 고려하여 props를 각 Type으로 전달하려고 할때 (Parent Component)
<img width="468" alt="Screen Shot 2022-02-01 at 11 58 41 am" src="https://user-images.githubusercontent.com/16056892/151907610-3d68fe38-ed2e-4d5e-ab39-8d17dcbcf121.png">
- Props Validation 을 고려하기 전 (Child Component)
<img width="238" alt="Screen Shot 2022-02-01 at 12 10 36 pm" src="https://user-images.githubusercontent.com/16056892/151907716-3d052c0f-0da1-4305-987e-0611e6070219.png">
- Props Validation 을 고려한 후 (Child Component)
<img width="288" alt="Screen Shot 2022-02-01 at 12 10 04 pm" src="https://user-images.githubusercontent.com/16056892/151907677-9258cb74-3600-4632-974d-bb99a74dda8c.png">


## 이번주 미션 정리
- TC 작성중, props가 undefined라는 에러에 고생했는데, props validation을 해주지 않아서 발생한 에러였다. Vue.js 공식 문서에 props validation(유효성 검사)에 대한 설명이 있는데 이를 바탕으로 props를 선언해주었다면 해결 가능한 문제 였습니다. 공식문서를 꼼꼼히 읽지 못 한것에 대하여 크게 반성했습니다.
- 이번주 미션들 통해 데이터들의 유효성검사의 필요와 중요성에 대하여 생각해볼 수 있었습니다.


* [ ] 본인의 구현 결과를 `dev` 브랜치에 구현하고, `dev` 브랜치에서 `submission` 브랜치로 PR을 보내주세요.

CC: @externship-master  @lkaybob 


