### PR TITLE
4주차 미션 제출 김호균

### DIFF
--- a/mission/package.json
+++ b/mission/package.json
@@ -9,6 +9,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "axios": "^0.25.0",
     "core-js": "^3.6.5",
     "source-map": "^0.7.3",
     "vue": "^3.0.0",

--- a/mission/package.json
+++ b/mission/package.json
@@ -9,7 +9,6 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "bulma": "^0.9.3",
     "core-js": "^3.6.5",
     "source-map": "^0.7.3",
     "vue": "^3.0.0",

--- a/mission/public/index.html
+++ b/mission/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />    <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.3/css/bulma.min.css" integrity="sha512-IgmDkwzs96t4SrChW29No3NXBIBv8baW490zk5aXvhCD8vuZM3yUSkbyTBcXohkySecyzIrUwiF/qV0cuPcL3Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/mission/src/App.vue
+++ b/mission/src/App.vue
@@ -1,19 +1,11 @@
 <template>
-  <Header />
   <router-view />
-  <BottomNav />
 </template>
 
 <script>
-import Header from '@/views/Header.vue';
-import BottomNav from '@/views/BottomNav.vue';
-
 export default {
   name: 'App',
-  components: {
-    Header,
-    BottomNav,
-  },
+  components: {},
 };
 </script>
 <style>

--- a/mission/src/assets/main.scss
+++ b/mission/src/assets/main.scss
@@ -1,1 +1,0 @@
-@import '~bulma';

--- a/mission/src/components/ItemList/Item.vue
+++ b/mission/src/components/ItemList/Item.vue
@@ -1,20 +1,22 @@
 <template>
-  <div class="has-text-left">
-    <img data-test="item-img" :src="product[0].image" />
-    <div class="has-text-weight-bold">
-      <span
-        v-if="isDiscounted"
-        :class="{ 'has-text-danger': isDiscounted }"
-        data-test="discount-rate"
-      >
-        {{ displayDiscountRate }}
-      </span>
-      <span data-test="final-price">{{ priceWithComma }}</span>
-    </div>
-    <h4 data-test="item-title">{{ product[0].name }}</h4>
-    <div data-test="item-discription" class="is-size-7">
-      {{ product[0].description }}
-    </div>
+  <div class="has-text-left" v-for="item in product" :key="item.product_no">
+    <router-link :to="{ name: 'item', params: { id: item.product_no } }">
+      <img data-test="item-img" :src="item.image" />
+      <div class="has-text-weight-bold">
+        <span
+          v-if="isDiscounted"
+          :class="{ 'has-text-danger': isDiscounted }"
+          data-test="discount-rate"
+        >
+          {{ displayDiscountRate }}
+        </span>
+        <span data-test="final-price">{{ priceWithComma }}</span>
+      </div>
+      <h4 data-test="item-title">{{ item.name }}</h4>
+      <div data-test="item-discription" class="is-size-7">
+        {{ item.description }}
+      </div>
+    </router-link>
   </div>
 </template>
 
@@ -36,6 +38,11 @@ export default {
         };
       },
     },
+  },
+  data() {
+    return {
+      item: {},
+    };
   },
   computed: {
     priceWithComma() {

--- a/mission/src/components/ItemList/Item.vue
+++ b/mission/src/components/ItemList/Item.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="has-text-left">
-    <img data-test="item-img" :src="img" />
+    <img data-test="item-img" :src="product[0].image" />
     <div class="has-text-weight-bold">
       <span
-        v-show="isDiscount"
-        :class="{ 'has-text-danger': isDiscount }"
+        v-if="isDiscounted"
+        :class="{ 'has-text-danger': isDiscounted }"
         data-test="discount-rate"
       >
-        {{ discountRate }}
+        {{ displayDiscountRate }}
       </span>
-      <span data-test="final-price">{{ finalPrice }}</span>
+      <span data-test="final-price">{{ priceWithComma }}</span>
     </div>
-    <h4 data-test="item-title">{{ title }}</h4>
+    <h4 data-test="item-title">{{ product[0].name }}</h4>
     <div data-test="item-discription" class="is-size-7">
-      {{ discription }}
+      {{ product[0].description }}
     </div>
   </div>
 </template>
@@ -22,54 +22,63 @@
 export default {
   name: 'ItemListItem',
   props: {
-    id: {
-      type: Number,
-      default: 1,
-      required: true,
+    product: {
+      type: Object,
+      default() {
+        return {
+          product_no: '',
+          name: '',
+          description: '',
+          price: 0,
+          original_price: 0,
+          image:
+            'https://projectlion-vue.s3.ap-northeast-2.amazonaws.com/items/suit-1.png',
+        };
+      },
     },
-    img: {
-      type: String,
-      default: 'https://picsum.photos/200',
-      required: true,
-    },
-    title: {
-      type: String,
-      default: '',
-      required: true,
-    },
-    isDiscount: {
-      type: Boolean,
-      default: false,
-      required: true,
-    },
-    discount_rate: {
-      type: Number,
-      default: null,
-      required: true,
-    },
-    original_price: {
-      type: Number,
-      default: 0,
-      required: true,
-    },
-    discription: {
-      type: String,
-      default: '',
-      required: true,
-    },
+    // id: {
+    //   type: String,
+    //   default: '',
+    // },
+    // img: {
+    //   type: String,
+    //   default:
+    //     'https://projectlion-vue.s3.ap-northeast-2.amazonaws.com/items/suit-1.png',
+    // },
+    // title: {
+    //   type: String,
+    //   default: '',
+    // },
+    // price: {
+    //   type: Number,
+    //   default: 0,
+    // },
+    // original_price: {
+    //   type: Number,
+    //   default: 0,
+    // },
+    // description: {
+    //   type: String,
+    //   default: '',
+    // },
   },
   computed: {
-    finalPrice() {
-      const price = this.original_price;
-      const rate = this.discount_rate;
-      const discount = this.isDiscount;
-      const discountedPrice = price - price * (rate / 100);
-      return discount
-        ? `${discountedPrice.toLocaleString()}원`
-        : `${price.toLocaleString()}원`;
+    priceWithComma() {
+      const { price } = this.product[0];
+      return `${price.toLocaleString()}원`;
     },
-    discountRate() {
-      return `${this.discount_rate}%`;
+    isDiscounted() {
+      const originalPrice = this.product[0].original_price;
+      return originalPrice !== 0;
+    },
+    displayDiscountRate() {
+      const originalPrice = this.product[0].original_price;
+      const { price } = this.product[0];
+
+      const dividend = originalPrice - price;
+      const divisor = originalPrice;
+      const rate = (dividend / divisor) * 100;
+      return `${rate.toFixed(0)}%`;
     },
   },
 };

--- a/mission/src/components/ItemList/Item.vue
+++ b/mission/src/components/ItemList/Item.vue
@@ -36,31 +36,6 @@ export default {
         };
       },
     },
-    // id: {
-    //   type: String,
-    //   default: '',
-    // },
-    // img: {
-    //   type: String,
-    //   default:
-    //     'https://projectlion-vue.s3.ap-northeast-2.amazonaws.com/items/suit-1.png',
-    // },
-    // title: {
-    //   type: String,
-    //   default: '',
-    // },
-    // price: {
-    //   type: Number,
-    //   default: 0,
-    // },
-    // original_price: {
-    //   type: Number,
-    //   default: 0,
-    // },
-    // description: {
-    //   type: String,
-    //   default: '',
-    // },
   },
   computed: {
     priceWithComma() {

--- a/mission/src/components/ItemList/Item.vue
+++ b/mission/src/components/ItemList/Item.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="has-text-left">
-    <img data-test="item-img" :src="item.img" />
+    <img data-test="item-img" :src="img" />
     <div class="has-text-weight-bold">
       <span
-        v-show="item.isDiscount"
-        :class="{ 'has-text-danger': item.isDiscount }"
+        v-show="isDiscount"
+        :class="{ 'has-text-danger': isDiscount }"
         data-test="discount-rate"
       >
         {{ discountRate }}
       </span>
       <span data-test="final-price">{{ finalPrice }}</span>
     </div>
-    <h4 data-test="item-title">{{ item.title }}</h4>
+    <h4 data-test="item-title">{{ title }}</h4>
     <div data-test="item-discription" class="is-size-7">
-      {{ item.discription }}
+      {{ discription }}
     </div>
   </div>
 </template>
@@ -22,20 +22,54 @@
 export default {
   name: 'ItemListItem',
   props: {
-    item: Object,
+    id: {
+      type: Number,
+      default: 1,
+      required: true,
+    },
+    img: {
+      type: String,
+      default: 'https://picsum.photos/200',
+      required: true,
+    },
+    title: {
+      type: String,
+      default: '',
+      required: true,
+    },
+    isDiscount: {
+      type: Boolean,
+      default: false,
+      required: true,
+    },
+    discount_rate: {
+      type: Number,
+      default: null,
+      required: true,
+    },
+    original_price: {
+      type: Number,
+      default: 0,
+      required: true,
+    },
+    discription: {
+      type: String,
+      default: '',
+      required: true,
+    },
   },
   computed: {
     finalPrice() {
-      const price = this.item.originalPrice;
-      const rate = this.item.discountRate;
-      const discount = this.item.isDiscount;
+      const price = this.original_price;
+      const rate = this.discount_rate;
+      const discount = this.isDiscount;
       const discountedPrice = price - price * (rate / 100);
       return discount
         ? `${discountedPrice.toLocaleString()}원`
         : `${price.toLocaleString()}원`;
     },
     discountRate() {
-      return `${this.item.discountRate}%`;
+      return `${this.discount_rate}%`;
     },
   },
 };

--- a/mission/src/main.js
+++ b/mission/src/main.js
@@ -3,6 +3,4 @@ import App from './App.vue';
 import router from './router';
 import store from './store';
 
-require('@/assets/main.scss');
-
 createApp(App).use(store).use(router).mount('#app');

--- a/mission/src/repositories/Clients/AxiosClient.js
+++ b/mission/src/repositories/Clients/AxiosClient.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+const baseDomain = 'https://virtserver.swaggerhub.com/lkaybob/projectlion-vue/1.0.0';
+const baseURL = `${baseDomain}`;
+
+export default axios.create({
+	baseURL,
+	headers: {
+		'Authorization': 'abcd1234'
+	}
+});

--- a/mission/src/repositories/ItemRepository.js
+++ b/mission/src/repositories/ItemRepository.js
@@ -1,0 +1,12 @@
+import Client from './Clients/AxiosClient';
+const resource = '/item';
+
+export default {
+	get() {
+		return Client.get(`${resource}`);
+	},
+	getItem(id) {
+		return Client.get(`${resource}/${id}`);
+	}
+
+}

--- a/mission/src/repositories/RepositoryFactory.js
+++ b/mission/src/repositories/RepositoryFactory.js
@@ -1,0 +1,9 @@
+import ItemRepository from './ItemRepository';
+
+const repositories = {
+	'item': ItemRepository,
+}
+
+export default {
+	get: name => repositories[name]
+};

--- a/mission/src/router/index.js
+++ b/mission/src/router/index.js
@@ -7,6 +7,12 @@ const routes = [
     name: 'Home',
     component: ItemListPage,
   },
+  {
+    path: '/item/:id',
+    name: 'item',
+    component: () => import('@/views/ItemInfo.vue'),
+    props: true,
+  },
   // {
   //   path: '/about',
   //   name: 'About',

--- a/mission/src/views/ItemInfo.vue
+++ b/mission/src/views/ItemInfo.vue
@@ -139,14 +139,12 @@
 </template>
 
 <script>
-import productImage from '@/assets/product-1.png';
-
 export default {
   name: 'ItemInfoPage',
   data() {
     return {
       sellerData: {
-        productImg: productImage,
+        productImg: 'https://picsum.photos/200',
         profilePic: 'https://picsum.photos/200',
         marketName: '대한양복',
         tags: ['#남성', '#수트'],

--- a/mission/src/views/ItemInfo.vue
+++ b/mission/src/views/ItemInfo.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="container">
-    <!-- <figure class="image is-square mobile">
-      <img data-test="product-image" :src="apiData.item.image" />
-    </figure> -->
+    <figure class="image is-square mobile">
+      <img :src="apiData.item.image" />
+    </figure>
     <img :src="apiData.item.image" />
     <div class="columns mt-1 mx-1 is-mobile">
       <div class="column is-one-fifth">
@@ -28,7 +28,6 @@
           #{{ tag }}
         </div>
       </div>
-      <div class="column is-one-fifth"></div>
     </div>
     <hr />
     <div class="columns mt-2 mx-2 is-mobile">
@@ -55,14 +54,8 @@
           </span>
         </div>
       </div>
-      <div class="column is-one-fifth">
-        <button
-          class="mt-5 mb-5 button is-primary"
-          @click="setDiscount"
-          data-test="apply-discount"
-        >
-          {{ sellerData.discountRate }}% 할인 적용
-        </button>
+      <div class="column is-offset-two-fifth">
+        <button></button>
       </div>
     </div>
     <section class="hero">
@@ -123,14 +116,14 @@
   <hr />
   <div class="navbar is-fixed-bottom">
     <button
-      v-if="sellerData.isDiscount == true"
+      v-if="isDiscounted"
       class="button mt-1"
       data-test="purchase-button-discount"
     >
-      {{ discountPrice }}원 구매
+      {{ priceWithComma }}구매
     </button>
     <button v-else class="button mt-1" data-test="purchase-button-non-discount">
-      {{ noDiscountPrice }}원 구매
+      {{ originalPriceWithComma }}구매
     </button>
   </div>
 </template>
@@ -144,56 +137,17 @@ export default {
   name: 'ItemInfoPage',
   data() {
     return {
-      sellerData: {
-        productImg: 'https://picsum.photos/200',
-        profilePic: 'https://picsum.photos/200',
-        marketName: '대한양복',
-        tags: ['#남성', '#수트'],
-        productName: '핏이 좋은 수트',
-        productPrice: 200000,
-        isDiscount: true,
-        discountRate: 10,
-        productDetail: {
-          description: '체형에 관계없이 누구에게나 맞는 수트!',
-          image: 'https://source.unsplash.com/random',
-        },
-      },
-      customerReviewData: [
-        {
-          customerName: 'spiderman',
-          timeStamp: '',
-          title: '만족해요',
-          description: '핏이 아주 잘 맞습니다. 대만족!',
-          image: 'https://picsum.photos/200',
-        },
-        {
-          customerName: 'ironman',
-          timeStamp: '',
-        },
-      ],
       apiData: {},
     };
   },
   created() {
     this.getItemInfos();
   },
-  mounted() {
-    /* Format Review Data */
-    const date = new Date();
-    const year = date.getFullYear();
-    const month = date.getMonth() + 1;
-    const day = date.getDate();
-    this.customerReviewData.timeStamp = `${year}. ${month}. ${day}`;
-    /* encrypt customer name on review - 추후구현 */
-    // this.customerReviewData.customerName.replace(/\/gi, "*");
-  },
   methods: {
-    setDiscount() {
-      this.sellerData.isDiscount = !this.sellerData.isDiscount;
-    },
-    async getItemInfos(id) {
-      const { data } = await ItemRepository.getItem(id);
+    async getItemInfos() {
+      const { data } = await ItemRepository.getItem();
       this.apiData = data;
+      console.log(this.apiData);
     },
   },
   computed: {

--- a/mission/src/views/ItemList.vue
+++ b/mission/src/views/ItemList.vue
@@ -1,19 +1,7 @@
 <template>
   <div class="container mb-5 pb-5" data-test="item-list-page">
-    <!-- <Item
-      v-for="item in items"
-      :description="item.description"
-      :img="item.image"
-      :title="item.name"
-      :original_price="item.original_price"
-      :price="item.price"
-      :id="item.product_no"
-      :key="item.product_no"
-      class="item mx-3 my-2"
-    /> -->
     <Item v-for="item in items" :key="item.id" :product="item" />
   </div>
-  {{ items }}
 </template>
 
 <script>

--- a/mission/src/views/ItemList.vue
+++ b/mission/src/views/ItemList.vue
@@ -1,18 +1,19 @@
 <template>
   <div class="container mb-5 pb-5" data-test="item-list-page">
-    <Item
+    <!-- <Item
       v-for="item in items"
-      :id="item.id"
-      :img="item.img"
-      :title="item.title"
-      :isDiscount="item.isDiscount"
-      :discount_rate="item.discount_rate"
+      :description="item.description"
+      :img="item.image"
+      :title="item.name"
       :original_price="item.original_price"
-      :discription="item.discription"
-      :key="item.id"
+      :price="item.price"
+      :id="item.product_no"
+      :key="item.product_no"
       class="item mx-3 my-2"
-    />
+    /> -->
+    <Item v-for="item in items" :key="item.id" :product="item" />
   </div>
+  {{ items }}
 </template>
 
 <script>
@@ -31,16 +32,15 @@ export default {
       items: [],
     };
   },
-  created() {
-    this.getItem();
-  },
   methods: {
     async getItem() {
       const { data } = await ItemRepository.get();
-      console.log(`Hello, ${data}`);
-
       this.items = data;
+      console.log(this.items);
     },
+  },
+  created() {
+    this.getItem();
   },
 };
 </script>

--- a/mission/src/views/ItemList.vue
+++ b/mission/src/views/ItemList.vue
@@ -1,12 +1,16 @@
 <template>
+  <Header />
   <div class="container mb-5 pb-5" data-test="item-list-page">
     <router-link :to="{ path: `/item/${items.items[0].product_no}` }">
       <Item v-for="item in items" :key="item.id" :product="item" />
     </router-link>
   </div>
+  <BottomNav />
 </template>
 
 <script>
+import Header from '@/views/Header.vue';
+import BottomNav from '@/views/BottomNav.vue';
 import Item from '@/components/ItemList/Item.vue';
 import Repository from '@/repositories/RepositoryFactory';
 
@@ -16,6 +20,8 @@ export default {
   name: 'ItemListPage',
   components: {
     Item,
+    Header,
+    BottomNav,
   },
   data() {
     return {

--- a/mission/src/views/ItemList.vue
+++ b/mission/src/views/ItemList.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="container mb-5 pb-5" data-test="item-list-page">
-    <Item v-for="item in items" :key="item.id" :product="item" />
+    <router-link :to="{ path: `/item/${items.items[0].product_no}` }">
+      <Item v-for="item in items" :key="item.id" :product="item" />
+    </router-link>
   </div>
 </template>
 
@@ -21,14 +23,14 @@ export default {
     };
   },
   methods: {
-    async getItem() {
+    async getItemLists() {
       const { data } = await ItemRepository.get();
       this.items = data;
       console.log(this.items);
     },
   },
   created() {
-    this.getItem();
+    this.getItemLists();
   },
 };
 </script>

--- a/mission/src/views/ItemList.vue
+++ b/mission/src/views/ItemList.vue
@@ -1,11 +1,9 @@
 <template>
-  <Header />
   <div class="container mb-5 pb-5" data-test="item-list-page">
-    <router-link :to="{ path: `/item/${items.items[0].product_no}` }">
-      <Item v-for="item in items" :key="item.id" :product="item" />
-    </router-link>
+    <Header />
+    <Item v-for="item in items" :key="item.id" :product="item" />
+    <BottomNav />
   </div>
-  <BottomNav />
 </template>
 
 <script>
@@ -25,7 +23,7 @@ export default {
   },
   data() {
     return {
-      items: [],
+      items: {},
     };
   },
   methods: {

--- a/mission/src/views/ItemList.vue
+++ b/mission/src/views/ItemList.vue
@@ -17,6 +17,9 @@
 
 <script>
 import Item from '@/components/ItemList/Item.vue';
+import Repository from '@/repositories/RepositoryFactory';
+
+const ItemRepository = Repository.get('item');
 
 export default {
   name: 'ItemListPage',
@@ -25,63 +28,19 @@ export default {
   },
   data() {
     return {
-      items: [
-        {
-          id: 1,
-          img: 'https://picsum.photos/200',
-          title: 'Item 1',
-          isDiscount: true,
-          discount_rate: 10,
-          original_price: 200000,
-          discription: '제품에 대한 설명입니다',
-        },
-        {
-          id: 2,
-          img: 'https://picsum.photos/200',
-          title: 'Item 2',
-          isDiscount: false,
-          discount_rate: 0,
-          original_price: 200000,
-          discription: '제품에 대한 설명입니다',
-        },
-        {
-          id: 3,
-          img: 'https://picsum.photos/200',
-          title: 'Item 3',
-          isDiscount: false,
-          discount_rate: 0,
-          original_price: 200000,
-          discription: '제품에 대한 설명입니다',
-        },
-        {
-          id: 4,
-          img: 'https://picsum.photos/200',
-          title: 'Item 4',
-          isDiscount: false,
-          discount_rate: 0,
-          original_price: 200000,
-          discription: '제품에 대한 설명입니다',
-        },
-        {
-          id: 5,
-          img: 'https://picsum.photos/200',
-          title: 'Item 4',
-          isDiscount: false,
-          discount_rate: 0,
-          original_price: 200000,
-          discription: '제품에 대한 설명입니다',
-        },
-        {
-          id: 6,
-          img: 'https://picsum.photos/200',
-          title: 'Item 4',
-          isDiscount: false,
-          discount_rate: 0,
-          original_price: 200000,
-          discription: '제품에 대한 설명입니다',
-        },
-      ],
+      items: [],
     };
+  },
+  created() {
+    this.getItem();
+  },
+  methods: {
+    async getItem() {
+      const { data } = await ItemRepository.get();
+      console.log(`Hello, ${data}`);
+
+      this.items = data;
+    },
   },
 };
 </script>

--- a/mission/src/views/ItemList.vue
+++ b/mission/src/views/ItemList.vue
@@ -2,7 +2,13 @@
   <div class="container mb-5 pb-5" data-test="item-list-page">
     <Item
       v-for="item in items"
-      :item="item"
+      :id="item.id"
+      :img="item.img"
+      :title="item.title"
+      :isDiscount="item.isDiscount"
+      :discount_rate="item.discount_rate"
+      :original_price="item.original_price"
+      :discription="item.discription"
       :key="item.id"
       class="item mx-3 my-2"
     />
@@ -25,8 +31,8 @@ export default {
           img: 'https://picsum.photos/200',
           title: 'Item 1',
           isDiscount: true,
-          discountRate: 10,
-          originalPrice: 200000,
+          discount_rate: 10,
+          original_price: 200000,
           discription: '제품에 대한 설명입니다',
         },
         {
@@ -34,8 +40,8 @@ export default {
           img: 'https://picsum.photos/200',
           title: 'Item 2',
           isDiscount: false,
-          discountRate: 0,
-          originalPrice: 200000,
+          discount_rate: 0,
+          original_price: 200000,
           discription: '제품에 대한 설명입니다',
         },
         {
@@ -43,8 +49,8 @@ export default {
           img: 'https://picsum.photos/200',
           title: 'Item 3',
           isDiscount: false,
-          discountRate: 0,
-          originalPrice: 200000,
+          discount_rate: 0,
+          original_price: 200000,
           discription: '제품에 대한 설명입니다',
         },
         {
@@ -52,8 +58,8 @@ export default {
           img: 'https://picsum.photos/200',
           title: 'Item 4',
           isDiscount: false,
-          discountRate: 0,
-          originalPrice: 200000,
+          discount_rate: 0,
+          original_price: 200000,
           discription: '제품에 대한 설명입니다',
         },
         {
@@ -61,8 +67,8 @@ export default {
           img: 'https://picsum.photos/200',
           title: 'Item 4',
           isDiscount: false,
-          discountRate: 0,
-          originalPrice: 200000,
+          discount_rate: 0,
+          original_price: 200000,
           discription: '제품에 대한 설명입니다',
         },
         {
@@ -70,8 +76,8 @@ export default {
           img: 'https://picsum.photos/200',
           title: 'Item 4',
           isDiscount: false,
-          discountRate: 0,
-          originalPrice: 200000,
+          discount_rate: 0,
+          original_price: 200000,
           discription: '제품에 대한 설명입니다',
         },
       ],

--- a/mission/tests/unit/ItemDetailRoute.spec.js
+++ b/mission/tests/unit/ItemDetailRoute.spec.js
@@ -1,0 +1,36 @@
+import { mount } from '@vue/test-utils';
+import { createRouter, createWebHistory } from 'vue-router';
+import App from '@/App.vue';
+import ItemInfo from '@/views/ItemInfo.vue';
+
+const router = createRouter({
+	history: createWebHistory(),
+	routes: [
+		{
+			path: '/',
+			component: App,
+		},
+		{
+			path: '/item/:id',
+			component: ItemInfo,
+		}
+	]
+})
+
+
+
+describe('Item 컴포넌트를 클릭하면 ItemInfo를 렌더링하는 라우팅이 이뤄지는지를 테스트 합니다', () => {
+	it('tests render ItemInfo Component via routing', async () => {
+		router.push('/item/asdf1234')
+		await router.isReady()
+
+		const wrapper = mount(App, {
+			global: {
+				plugins: [router]
+			}
+		})
+
+		expect(wrapper.findComponent(ItemInfo).exists()).toBe(true)
+	})
+})
+


### PR DESCRIPTION
# 4주차 미션 제출 (김호균)

   ## 접근방법(고민한 내용)

- 4주차 미션에서는 기존의 static 한 데이터들을 Mock Api를 활용하여 데이터들을 렌더링 해줘야 했습니다.
- 금주차 기능구현을 진행하던중 화면상에 보여지는 부분에서는 이상이 없었으나, TC작성시 경고와 vue warning, 콘솔에러등 내부적으로 이슈가 많아 이점들을 분석하고 해결하고자하는 노력을 기울였습니다.
- 이점들을 놓치고 디벨롭을 진행하고 싶진 않았기에, 추가적인 코드 작성이 다소 부족할수있습니다.
    
    기능구현 요구사항
    
    - (목표)
        - 3주차에서 개발했던 상품 목록 페이지에서 개별 상품에 대한 링크를 추가해야하며, 개별 링크는 각 상품에 대한 상품 상세 정보 페이지로 전환이 되어야 합니다.
        - 2주차에서 개발했던 상품 상세정보 페이지는 “/item/1”과 같은 주소로 접근이 되어야 합니다.
        - 예시의 “1”은 각 상품에 대한 고유 번호로, 고유 번호가 바뀔 경우 그에 상응하는 상품 정보가 표시되도록 라우팅이 구현되어야 합니다. (힌트: Dynamic Route Matching with Params)
        - 제시된 Mock API는 id를 달리해도 똑같은 상품 정보가 반환되도록 구성이 되어 있습니다.
        - API 연동을 할 때는 일명 Repository pattern을 활용하여 수행해주셔야 합니다.
        - 즉, 컴포넌트 파일 안에서 HTTP client를 직접 호출하지 않아야 합니다.
    - (시도)
        1. router-link to의 선언을 Item.vue에 작성하였고, ItemList에서 받아올 api의 product_no의 값을 props로 dynamic routing을 진행하였습니다.
        2. Axios를 활용하여 repository pattern을 준수한 구조로 해당 컴포넌트에서 필요로할 데이터들을 요청하였습니다. 
    
    ## 특이사항(질문사항)
    
    ### 1. css framework 적용시 cdn vs module - (해당 질문사항은 3주차 PR 코멘트 reply에서 충분한 대답을 얻었습니다)
    
    - 설 연휴 주간에 3주차코드 리펙토링과 차후 주차에서는 cypress를 활용한 e2e TC를 작성해보고자 따로 브렌치를 만들어 cypress 세팅을 진행하던중 제가 활용한 bulma css framework의 패키지들이 충돌하는 상황을 마주했습니다.
    - 정확히는 bulma css framework를 활용하기 위한 sass-loader와 cypress의 테스팅을 위한 패키지의 충돌로 보여졌기에, e2e TC 작성으로의 확장을 고려하여 node_module의 충돌을 피하고자 css framework을 cdn link tag을 활용하여 로딩하고자 했습니다.
    - cdn 을 활용하는 것은 어플리케이션 에서 페이지 로딩시 서버로부터(외부) 요청이 이루어지는 것이기 때문에 초기 렌더링 성능 저하를 일으킬수도 있을것이라고 생각하는데, 패키지 충돌 이슈를 먼저 해결하고자 부득이하게 cdn을 활용하여 css 로딩을 진행하였습니다.
    
    ### 2. API data type에 따른 적절한 data interpolation - (해당 질문사항은 2월 8일 Live 세션에서 해답을 얻었습니다)
    
- curl -X GET "[https://virtserver.swaggerhub.com/lkaybob/projectlion-vue/1.0.0/item[](https://www.notion.so/Sentiment-Analysis-c2b79f6d91954ac8ad02a0a6386a926a)](https://virtserver.swaggerhub.com/lkaybob/projectlion-vue/1.0.0/item)" -H "accept: application/json" -H "Authorization: abcd1234" 의 명령어로 response body를 살펴보면 아래와 같았습니다.

```jsx
{
  "items": [
    {
      "product_no": "asdf1234",
      "name": "핏이 좋은 수트",
      "image": "https://projectlion-vue.s3.ap-northeast-2.amazonaws.com/items/suit-1.png",
      "price": 198000,
      "original_price": 298000,
      "description": "아주 잘 맞는 수트"
    }
  ]
}
```

- 위의 데이터를 바탕으로 데이터 형태를 확인하면 아래와 같습니다.
<img width="649" alt="Screen Shot 2022-02-06 at 6 24 35 pm" src="https://user-images.githubusercontent.com/16056892/152674752-ac322339-49c2-4693-ae2c-1e456b8494c3.png">

- 이전 주차의 props 전달은 child component에서 데이터를 전달 받으려고 했다면 props에 value 값이 전달되지 않는 상황이 있었습니다
<img width="696" alt="Screen Shot 2022-02-06 at 6 25 43 pm" src="https://user-images.githubusercontent.com/16056892/152674782-6af619ad-95dd-4105-beee-3b03f60a9494.png">

- props의 key 값은 전달이 되는데 어째서 value만 전달이 안되는 현상이 생긴건지 궁금합니다..

```jsx
<!-- ItemList.vue -->
<Item v-for="item in items" :key="item.id" :product="item" />
```

```jsx
<!-- Item.vue -->
<script>
export default {
  name: 'ItemListItem',
  props: {
    product: {
      type: Object,
      default() {
        return {
          product_no: '',
          name: '',
          description: '',
          price: 0,
          original_price: 0,
          image:
            'https://projectlion-vue.s3.ap-northeast-2.amazonaws.com/items/suit-1.png',
        };
      },
    },
  },
</script>
```

- 하지만 전달된 product의 이름을 가지는 props 는 n개 이상의 array로 구성이 되어있어, Item.vue에서 props 데이터에 접근하려면 인덱싱을 진행해야했습니다

```jsx
{{ product.items[0].props-key }} 
```

- template 상에서 위와같이 인덱스를 직접적으로 명시해야하는 부분은 최대한 지양하고자 Item.vue template의 최상단 div 엘리먼트를 v-for를 작성하였습니다.

```jsx
<div class="has-text-left" v-for="item in product" :key="item.product_no">
	// omitted codes for brevity 
</div>
```

- 최상단 div를 v-for로 감싸주었더니, 데이터를 직접적으로 인덱싱 해주지 않아도 데이터 렌더링을 성공적으로 구현했습니다.

```jsx
{{ item.props_key}} // 로 데이터 렌더링 가능
```

- 위의 접근방식이 올바른지에 대한 코멘트가 가능하신지 여쭤보고 싶습니다.

### 3. Data property에 validation적용이 가능한지의 여부

- 4주차 미션을 진행하면서 가장 시간투자와 생각을 많이 해보게된 내용입니다.
- 해당 특이사항은 사실 routing TC를 작성하면서 찾아낸 에러를 해결하고자 생각한 내용입니다.
    
<img width="704" alt="Screen Shot 2022-02-06 at 6 26 31 pm" src="https://user-images.githubusercontent.com/16056892/152674805-2de18b07-a1f6-4e60-a981-2bbe19cc1b22.png">
    
- 해당 에러가 발생하는 이유에 대해서는 아래와 같이 고민해보았습니다.
    - 컴포넌트가 마운트되는 시점과 api data를 받아오는 비동기적 함수가 실행되는 지점의 불일치(?)
- Api명세서에서 상품의 상세정보 조회를 받아오는 get 요청이 /item/{itemNo} 명시되어있기에, 아래의 코드와 같이 ItemInfo.vue에서 api data를 호출하는 함수로 data property에 api 데이터를 넣어줘야한다고 생각했습니다.
- 그렇기에 property undefined에러를 props의 validation으로 처리하기보다는 혹시 data property에서 default값을 처리해줄수 있을지에 대한 고민을 해보았으나 해결책을 찾을수 없었습니다.

```jsx
<!-- ItemInfo.vue -->
export default {
  name: 'ItemInfoPage',
  data() {
    return {
      apiData: {},
    };
  },
  created() {
    this.getItemInfos();
  },
  methods: {
    async getItemInfos() {
      const { data } = await ItemRepository.getItem();
      this.apiData = data;
      console.log(this.apiData);
    },
  },
}
```

- 해당 data property의 네이밍을 item으로 선언하려고하였으나, api로 부터 받을 데이터 구조에 ‘item’으로 명시되어 있어 apiData로 중복을 피하고자 했습니다. FE 단에서 좀 더 혼선을 줄일수있을 네이밍 컨벤션이 있을까 궁금합니다.

```jsx
<!-- data property의 naming이 api 로받을 data와 중복일때 추천하는 naming convetion? -->

data() {
	return {
		item: {
			item: {
				//api로 부터 추가될 key:value
			}
		}
	}
}
```
CC: @externship-master  @lkaybob 


